### PR TITLE
[Query Bug/HACK] Remove mutex locks in local client

### DIFF
--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -86,8 +86,8 @@ func (app *localClient) Echo(_ context.Context, msg string) (*types.ResponseEcho
 }
 
 func (app *localClient) Info(ctx context.Context, req *types.RequestInfo) (*types.ResponseInfo, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
+	// app.mtx.Lock()
+	// defer app.mtx.Unlock()
 
 	return app.Application.Info(ctx, req)
 }
@@ -100,8 +100,8 @@ func (app *localClient) CheckTx(ctx context.Context, req *types.RequestCheckTx) 
 }
 
 func (app *localClient) Query(ctx context.Context, req *types.RequestQuery) (*types.ResponseQuery, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
+	// app.mtx.Lock()
+	// defer app.mtx.Unlock()
 
 	return app.Application.Query(ctx, req)
 }

--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -86,6 +86,7 @@ func (app *localClient) Echo(_ context.Context, msg string) (*types.ResponseEcho
 }
 
 func (app *localClient) Info(ctx context.Context, req *types.RequestInfo) (*types.ResponseInfo, error) {
+	// TODO_HACK(#3): This is a hack to avoid RPC queries being blocked by heavy/slow EndBlockers.
 	// app.mtx.Lock()
 	// defer app.mtx.Unlock()
 
@@ -100,6 +101,7 @@ func (app *localClient) CheckTx(ctx context.Context, req *types.RequestCheckTx) 
 }
 
 func (app *localClient) Query(ctx context.Context, req *types.RequestQuery) (*types.ResponseQuery, error) {
+	// TODO_HACK(#3): This is a hack to avoid RPC queries being blocked by heavy/slow EndBlockers.
 	// app.mtx.Lock()
 	// defer app.mtx.Unlock()
 


### PR DESCRIPTION
- Remove mutexes in Query/Info read calls
- Full details here: https://github.com/pokt-network/cometbft/issues/3